### PR TITLE
Avoid erroring out for failed getStrings

### DIFF
--- a/device.go
+++ b/device.go
@@ -200,9 +200,7 @@ func FindAll(vendor, product int) ([]*USBDev, error) {
 		u.d = devs[i]
 		C.libusb_ref_device(u.d)
 		runtime.SetFinalizer(u, (*USBDev).unref)
-		if err := u.getStrings(u.d, ds); err != nil {
-			return nil, err
-		}
+		u.getStrings(u.d, ds)
 		ret[n] = u
 		n++
 	}


### PR DESCRIPTION
When running FindAll on a system that contains FTDI devices for which
no driver has been installed, the function would return an error,
propagated from the call to libusb_open needed for getStrings. It does
make sense that libusb_open fails, but the way the error is propagated
means that FindAll will always return an error, which is more surprising
given that it is just an enumeration function.

This commit changes the behavior so that FindAll will not fail, but
simply return an empty USBDev structure for those devices, so that the
caller can realize that a device is present but cannot be queried or
accessed.